### PR TITLE
Improve mobile gallery responsiveness and image sizing

### DIFF
--- a/photography/style.css
+++ b/photography/style.css
@@ -256,8 +256,22 @@ h1 {
     }
 }
 @media (max-width: 600px) {
+    .justified-gallery {
+        display: block;
+    }
+    .justified-gallery::after {
+        display: none;
+    }
     .gallery-item {
-        height: 180px;
+        height: auto;
+        margin-bottom: 8px;
+        background: transparent;
+    }
+    .gallery-item img {
+        width: 100%;
+        height: auto;
+        max-height: none;
+        object-fit: contain;
     }
     nav {
         padding: 1.5rem 2rem;


### PR DESCRIPTION
### Motivation
- Make the gallery layout usable on small screens by preventing forced fixed heights and ensuring images scale without cropping in the justified gallery layout.

### Description
- Add rules inside `@media (max-width: 600px)` to make the `justified-gallery` use block layout and hide its `::after` pseudo-element.
- Change `gallery-item` sizing for small screens from `height: 180px` to `height: auto` and add `margin-bottom: 8px` and `background: transparent` to allow natural flow.
- Add responsive image rules `gallery-item img { width: 100%; height: auto; max-height: none; object-fit: contain; }` so images scale correctly and maintain aspect ratio.
- Keep the existing `@media (max-width: 1000px)` adjustment for `gallery-item` while refining behavior for narrower viewports.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5335151888320a5c728c009838b03)