### PR TITLE
Make gallery responsive on small screens by stacking items and adjusting sizing

### DIFF
--- a/photography/script.js
+++ b/photography/script.js
@@ -39,6 +39,7 @@ const photoLinks = [
 function renderGallery() {
     const container = document.getElementById("photo-container");
     if (!container) return;
+    const isMobileView = window.matchMedia("(max-width: 600px)").matches;
 
     // --- SHUFFLE ENABLED ---
     shuffleArray(photoLinks);
@@ -59,11 +60,14 @@ function renderGallery() {
            CSS exactly how wide this box should be relative to its height.
            This prevents cropping and weird stretching. */
         img.onload = () => {
-            const aspectRatio = img.naturalWidth / img.naturalHeight;
-            div.style.flexGrow = aspectRatio;
-
-            // UPDATED: 250 matches your new CSS height
-            div.style.flexBasis = aspectRatio * 200 + "px";
+            if (!isMobileView) {
+                const aspectRatio = img.naturalWidth / img.naturalHeight;
+                div.style.flexGrow = aspectRatio;
+                div.style.flexBasis = aspectRatio * 200 + "px";
+            } else {
+                div.style.flexGrow = "unset";
+                div.style.flexBasis = "100%";
+            }
         };
 
         div.appendChild(img);

--- a/photography/style.css
+++ b/photography/style.css
@@ -256,8 +256,26 @@ h1 {
     }
 }
 @media (max-width: 600px) {
+    .justified-gallery {
+        display: grid;
+        grid-template-columns: 1fr;
+        gap: 8px;
+    }
+    .justified-gallery::after {
+        display: none;
+    }
     .gallery-item {
-        height: 180px;
+        height: auto;
+        margin-bottom: 0;
+        background: transparent;
+        width: 100%;
+    }
+    .gallery-item img {
+        width: 100%;
+        height: auto;
+        max-height: none;
+        object-fit: contain;
+        aspect-ratio: auto;
     }
     nav {
         padding: 1.5rem 2rem;


### PR DESCRIPTION
### Motivation
- Prevent layout issues and stretched/cropped images on narrow viewports by disabling the justified flex sizing when the viewport is small. 
- Improve mobile readability by making each photo take full width and using intrinsic image sizing rather than flex-based aspect calculations.

### Description
- Add a mobile check using `window.matchMedia("(max-width: 600px)")` inside `renderGallery` and skip the aspect-ratio flex sizing in the `img.onload` handler when on mobile. 
- For mobile, set `div.style.flexGrow = "unset"` and `div.style.flexBasis = "100%"` so items stack full width. 
- Update CSS under `@media (max-width: 600px)` to switch `.justified-gallery` to a single-column grid, remove the gallery pseudo-element, set `.gallery-item` to `height: auto` and `width: 100%`, and add `.gallery-item img` rules (`width: 100%`, `height: auto`, `object-fit: contain`, `aspect-ratio: auto`) to preserve image proportions.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5335151888320a5c728c009838b03)